### PR TITLE
[DOJO-12] Status と Difficulty の色設定を tailwind.config.js に追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,11 @@ body {
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --status-done: #4da533;
+    --status-reviewed: #6284e2;
+    --difficulty-easy: #14baa7;
+    --difficulty-medium: #f3b516;
+    --difficulty-hard: #dd2a4e;
   }
   .dark {
     --background: 0 0% 3.9%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -59,7 +59,16 @@ const config: Config = {
   				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
   				border: 'hsl(var(--sidebar-border))',
   				ring: 'hsl(var(--sidebar-ring))'
-  			}
+  			},
+			status: {
+				done: 'var(--status-done)',
+				reviewed: 'var(--status-reviewed)'
+			},
+			difficulty: {
+				easy: 'var(--difficulty-easy)',
+				medium: 'var(--difficulty-medium)',
+				hard: 'var(--difficulty-hard)'
+			}
   		},
   		borderRadius: {
   			lg: 'var(--radius)',


### PR DESCRIPTION
# jira
- https://alpha-dojo.atlassian.net/browse/DOJO-12

# 対応内容

- globals.css にカラーを追加
  - https://github.com/Greek-Academy/alpha-dojo-v2/pull/1 に合わせて、 16進数で追加
- tailwind.config.ts から globals.css に追加した変数を使用