### PR TITLE
[DOJO 23] discord 通知の改修

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -10,12 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Discord Message
-        uses: appleboy/discord-action@master
-        with:
-          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
-          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          username: "GitHub Bot"
-          content: |
-            A new Pull Request has been opened:
-            **${{ github.event.pull_request.title }}**.
-            PR Link: ${{ github.event.pull_request.html_url }}
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+            -d '{
+              "content": "A new Pull Request has been opened: **${{ github.event.pull_request.title }}**\n<${{ github.event.pull_request.html_url }}>"
+            }' \
+            https://discord.com/api/webhooks/${{ secrets.DISCORD_WEBHOOK_ID }}/${{ secrets.DISCORD_WEBHOOK_TOKEN }}


### PR DESCRIPTION
# Jira
- https://alpha-dojo.atlassian.net/browse/DOJO-23

# 対応内容
- 通知がきていなかったので、改修しました
- https://github.com/marketplace/actions/discord-message-notify をやめてcurl で通知を出すように修正
