### PR TITLE
[DOJO-19] コンポーネントの作成 (Tabs)

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -30,7 +30,7 @@ const TabsList = React.forwardRef<
       // shadcn original:
       // "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
       "inline-flex h-10 items-center justify-center bg-neutral-200 p-1 text-muted-foreground",
-      "gap-1 !flex !justify-start",
+      "gap-1 flex justify-start",
       className
     )}
     {...props}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -5,7 +5,20 @@ import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"
 
-const Tabs = TabsPrimitive.Root
+const Tabs = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Root
+    ref={ref}
+    className={cn(
+      "rounded-xl overflow-hidden border",
+      className
+    )}
+    {...props}
+  />
+))
+Tabs.displayName = TabsPrimitive.Root.displayName
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -14,7 +27,10 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      // shadcn original:
+      // "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center bg-neutral-200 p-1 text-muted-foreground",
+      "gap-1 !flex !justify-start",
       className
     )}
     {...props}
@@ -26,14 +42,22 @@ const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-      className
-    )}
-    {...props}
-  />
+  <>
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        // shadcn original:
+        // "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-4 py-1.5 text-label-medium-prominent font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        "gap-2 !w-auto",
+        // 子要素の Material Symbols のフォントサイズは 18px が既定
+        '[&_[class^="material-symbols-"]]:[&>_]:text-[18px]',
+        className
+      )}
+      {...props}
+    />
+    <div className="bg-neutral-400 w-px h-5 last:hidden" />
+  </>
 ))
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
@@ -44,7 +68,10 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      // shadcn original:
+      // "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "flex-grow",
       className
     )}
     {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -85,6 +85,9 @@ const config: Config = {
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
   		},
+		fontSize: {
+			"label-medium-prominent": ['12px', {fontWeight: '600', letterSpacing: '0.5px', lineHeight: '16px'}]
+		}
   	}
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
# Jira
[DOJO-19](https://alpha-dojo.atlassian.net/browse/DOJO-19?atlOrigin=eyJpIjoiZDdlYjU5NjA3M2ViNDRhMDllYjM0ZjZkZTlkYjBlZWUiLCJwIjoiaiJ9)

# 内容
Tabs コンポーネントを Dojo 仕様に変更しました。
[DOJO-31](https://alpha-dojo.atlassian.net/browse/DOJO-31?atlOrigin=eyJpIjoiNmQ1NWYyMTRhOTY5NDI0ZWI0ZjBmOGYzYTk5NTJmYWYiLCJwIjoiaiJ9) の React-Grid-Layout の適用のためにデザインを修正しています。

# 変更点・注意点
* shadcn の Tabs に仕様を追加しています。
Tabs の高さを指定すると、それに合わせてタブの内容も伸縮するようにしました。
(従来はタブの内容に h-full を指定していたが、親要素からはみ出てしまいレイアウトが重なる)
* Tabs のタブ切り替えボタンについて、公式チュートリアルでは `diplay: grid` で等幅中央揃えに調整していますが、
仕様変更で `display: flex` を適用したため `display: grid` では調整できなくなりました。
今後は Flexbox で調整してください

# 問題点
* タブの切り替えボタンの部分の仕切り線についてですが、
かなり強引にやってます
(幅 1px の div 要素に背景色をつけた)
    * Radix UI に Separator っていうのを見つけたので、今後採用します

# スクリーンショット
![image](https://github.com/user-attachments/assets/e0fb5809-54cd-4fc0-9e5b-2cf1eea7737c)
