### PR TITLE
[DOJO-31] Splitter の適用

### DIFF
--- a/app/components/code-tab.tsx
+++ b/app/components/code-tab.tsx
@@ -1,10 +1,17 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 import { Code } from 'lucide-react';
 
-export const CodeTab = () => {
+export const CodeTab = ({ className }: { className?: string }) => {
   return (
-    <Tabs defaultValue="code" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */>
+    <Tabs
+      defaultValue="code"
+      className={cn(
+        'h-full flex flex-col [&:not(:first-child)]:*:flex-grow',
+        className
+      )} /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */
+    >
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="code" className="w-full">
           <Code size="14" />

--- a/app/components/code-tab.tsx
+++ b/app/components/code-tab.tsx
@@ -8,18 +8,18 @@ export const CodeTab = ({ className }: { className?: string }) => {
     <Tabs
       defaultValue="code"
       className={cn(
-        'h-full flex flex-col [&:not(:first-child)]:*:flex-grow',
+        'h-full',
         className
-      )} /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */
+      )}
     >
-      <TabsList className="grid w-full grid-cols-3">
-        <TabsTrigger value="code" className="w-full">
+      <TabsList>
+        <TabsTrigger value="code">
           <Code size="14" />
           code
         </TabsTrigger>
       </TabsList>
       <TabsContent value="code">
-        <Card className="h-full">
+        <Card className="border-0 shadow-none">
           <CardContent className="space-y-2">
             ここにコードを書きます。。
           </CardContent>

--- a/app/components/code-tab.tsx
+++ b/app/components/code-tab.tsx
@@ -5,13 +5,7 @@ import { Code } from 'lucide-react';
 
 export const CodeTab = ({ className }: { className?: string }) => {
   return (
-    <Tabs
-      defaultValue="code"
-      className={cn(
-        'h-full',
-        className
-      )}
-    >
+    <Tabs defaultValue="code" className={cn('h-full', className)}>
       <TabsList>
         <TabsTrigger value="code">
           <Code size="14" />

--- a/app/components/code-tab.tsx
+++ b/app/components/code-tab.tsx
@@ -4,24 +4,20 @@ import { Code } from 'lucide-react';
 
 export const CodeTab = () => {
   return (
-    <Card className="w-full h-full">
-      <Tabs defaultValue="code" className="w-full h-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="code" className="w-full">
-            <Code size="14" />
-            code
-          </TabsTrigger>
-        </TabsList>
-        <div className="h-full">
-          <TabsContent value="code" className="h-full bg-white">
-            <Card className="h-full">
-              <CardContent className="space-y-2">
-                ここにコードを書きます。。
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </div>
-      </Tabs>
-    </Card>
+    <Tabs defaultValue="code" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-31 で実装予定なので、今後不要 */>
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger value="code" className="w-full">
+          <Code size="14" />
+          code
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="code">
+        <Card className="h-full">
+          <CardContent className="space-y-2">
+            ここにコードを書きます。。
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
   );
 };

--- a/app/components/code-tab.tsx
+++ b/app/components/code-tab.tsx
@@ -4,7 +4,7 @@ import { Code } from 'lucide-react';
 
 export const CodeTab = () => {
   return (
-    <Tabs defaultValue="code" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-31 で実装予定なので、今後不要 */>
+    <Tabs defaultValue="code" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */>
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="code" className="w-full">
           <Code size="14" />

--- a/app/components/problem-tab.tsx
+++ b/app/components/problem-tab.tsx
@@ -10,7 +10,7 @@ import { ClipboardPenLine, FileText, FlaskConical } from 'lucide-react';
 
 export const ProbremTab = () => {
   return (
-    <Tabs defaultValue="description" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-31 で実装予定なので、今後不要 */>
+    <Tabs defaultValue="description" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */>
       <TabsList className="grid grid-cols-3">
         <TabsTrigger value="description">
           <FileText size="14" />

--- a/app/components/problem-tab.tsx
+++ b/app/components/problem-tab.tsx
@@ -6,11 +6,18 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 import { ClipboardPenLine, FileText, FlaskConical } from 'lucide-react';
 
-export const ProbremTab = () => {
+export const ProbremTab = ({ className }: { className?: string }) => {
   return (
-    <Tabs defaultValue="description" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */>
+    <Tabs
+      defaultValue="description"
+      className={cn(
+        'h-full flex flex-col [&:not(:first-child)]:*:flex-grow',
+        className
+      )} /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */
+    >
       <TabsList className="grid grid-cols-3">
         <TabsTrigger value="description">
           <FileText size="14" />

--- a/app/components/problem-tab.tsx
+++ b/app/components/problem-tab.tsx
@@ -14,11 +14,11 @@ export const ProbremTab = ({ className }: { className?: string }) => {
     <Tabs
       defaultValue="description"
       className={cn(
-        'h-full flex flex-col [&:not(:first-child)]:*:flex-grow',
+        'h-full',
         className
-      )} /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */
+      )}
     >
-      <TabsList className="grid grid-cols-3">
+      <TabsList>
         <TabsTrigger value="description">
           <FileText size="14" />
           Description
@@ -32,7 +32,7 @@ export const ProbremTab = ({ className }: { className?: string }) => {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="description">
-        <Card className="h-full bg-neutral-100">
+        <Card className='border-0 shadow-none'>
           <CardHeader>
             <CardTitle>最大の利益を持つ期間を探せ</CardTitle>
           </CardHeader>
@@ -42,8 +42,8 @@ export const ProbremTab = ({ className }: { className?: string }) => {
           <CardFooter>Footer...</CardFooter>
         </Card>
       </TabsContent>
-      <TabsContent value="submissions" className="bg-white">
-        <Card className="h-full bg-gray-100">
+      <TabsContent value="submissions">
+        <Card className='border-0 shadow-none'>
           <CardHeader>
             <CardTitle>Submissions</CardTitle>
           </CardHeader>
@@ -51,8 +51,8 @@ export const ProbremTab = ({ className }: { className?: string }) => {
           <CardFooter>Footer...</CardFooter>
         </Card>
       </TabsContent>
-      <TabsContent value="solutions" className="bg-white">
-        <Card className="h-full bg-gray-100">
+      <TabsContent value="solutions">
+        <Card className='border-0 shadow-none'>
           <CardHeader>
             <CardTitle>Solutions</CardTitle>
           </CardHeader>

--- a/app/components/problem-tab.tsx
+++ b/app/components/problem-tab.tsx
@@ -10,55 +10,51 @@ import { ClipboardPenLine, FileText, FlaskConical } from 'lucide-react';
 
 export const ProbremTab = () => {
   return (
-    <Card className="row-span-2 w-full h-full">
-      <Tabs defaultValue="description" className="w-full h-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="description" className="w-full">
-            <FileText size="14" />
-            Description
-          </TabsTrigger>
-          <TabsTrigger value="submissions" className="w-full">
-            <ClipboardPenLine size="14" />
-            Submissions
-          </TabsTrigger>
-          <TabsTrigger value="solutions" className="w-full">
-            <FlaskConical size="14" /> Solutions
-          </TabsTrigger>
-        </TabsList>
-        <div className="h-full">
-          <TabsContent value="description" className="h-full">
-            <Card className="h-full bg-gray-100">
-              <CardHeader>
-                <CardTitle>最大の利益を持つ期間を探せ</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                あなたはとある店舗のマネージャーです。・・・・・問題文が続きます。
-              </CardContent>
-              <CardFooter>Footer...</CardFooter>
-            </Card>
-          </TabsContent>
-          <TabsContent value="submissions" className="h-full bg-white">
-            <Card className="h-full bg-gray-100">
-              <CardHeader>
-                <CardTitle>Submissions</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">回答が並びます。</CardContent>
-              <CardFooter>Footer...</CardFooter>
-            </Card>
-          </TabsContent>
-          <TabsContent value="solutions" className="h-full bg-white">
-            <Card className="h-full bg-gray-100">
-              <CardHeader>
-                <CardTitle>Solutions</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                正解者の答えが出てきます。
-              </CardContent>
-              <CardFooter>Footer...</CardFooter>
-            </Card>
-          </TabsContent>
-        </div>
-      </Tabs>
-    </Card>
+    <Tabs defaultValue="description" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-31 で実装予定なので、今後不要 */>
+      <TabsList className="grid grid-cols-3">
+        <TabsTrigger value="description">
+          <FileText size="14" />
+          Description
+        </TabsTrigger>
+        <TabsTrigger value="submissions">
+          <ClipboardPenLine size="14" />
+          Submissions
+        </TabsTrigger>
+        <TabsTrigger value="solutions">
+          <FlaskConical size="14" /> Solutions
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="description">
+        <Card className="h-full bg-neutral-100">
+          <CardHeader>
+            <CardTitle>最大の利益を持つ期間を探せ</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            あなたはとある店舗のマネージャーです。・・・・・問題文が続きます。
+          </CardContent>
+          <CardFooter>Footer...</CardFooter>
+        </Card>
+      </TabsContent>
+      <TabsContent value="submissions" className="bg-white">
+        <Card className="h-full bg-gray-100">
+          <CardHeader>
+            <CardTitle>Submissions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">回答が並びます。</CardContent>
+          <CardFooter>Footer...</CardFooter>
+        </Card>
+      </TabsContent>
+      <TabsContent value="solutions" className="bg-white">
+        <Card className="h-full bg-gray-100">
+          <CardHeader>
+            <CardTitle>Solutions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            正解者の答えが出てきます。
+          </CardContent>
+          <CardFooter>Footer...</CardFooter>
+        </Card>
+      </TabsContent>
+    </Tabs>
   );
 };

--- a/app/components/problem-tab.tsx
+++ b/app/components/problem-tab.tsx
@@ -11,13 +11,7 @@ import { ClipboardPenLine, FileText, FlaskConical } from 'lucide-react';
 
 export const ProbremTab = ({ className }: { className?: string }) => {
   return (
-    <Tabs
-      defaultValue="description"
-      className={cn(
-        'h-full',
-        className
-      )}
-    >
+    <Tabs defaultValue="description" className={cn('h-full', className)}>
       <TabsList>
         <TabsTrigger value="description">
           <FileText size="14" />
@@ -32,7 +26,7 @@ export const ProbremTab = ({ className }: { className?: string }) => {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="description">
-        <Card className='border-0 shadow-none'>
+        <Card className="border-0 shadow-none">
           <CardHeader>
             <CardTitle>最大の利益を持つ期間を探せ</CardTitle>
           </CardHeader>
@@ -43,7 +37,7 @@ export const ProbremTab = ({ className }: { className?: string }) => {
         </Card>
       </TabsContent>
       <TabsContent value="submissions">
-        <Card className='border-0 shadow-none'>
+        <Card className="border-0 shadow-none">
           <CardHeader>
             <CardTitle>Submissions</CardTitle>
           </CardHeader>
@@ -52,7 +46,7 @@ export const ProbremTab = ({ className }: { className?: string }) => {
         </Card>
       </TabsContent>
       <TabsContent value="solutions">
-        <Card className='border-0 shadow-none'>
+        <Card className="border-0 shadow-none">
           <CardHeader>
             <CardTitle>Solutions</CardTitle>
           </CardHeader>

--- a/app/components/test-tab.tsx
+++ b/app/components/test-tab.tsx
@@ -10,55 +10,51 @@ import { MonitorCheck, SquareCheckBig, Text } from 'lucide-react';
 
 export const TestTab = () => {
   return (
-    <Card className="w-full h-full">
-      <Tabs defaultValue="testcase" className="w-full h-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="testcase" className="w-full">
-            <SquareCheckBig size="14" />
-            Test Case
-          </TabsTrigger>
-          <TabsTrigger value="testresult" className="w-full">
-            <MonitorCheck size="14" />
-            Test Result
-          </TabsTrigger>
-          <TabsTrigger value="lintresult" className="w-full">
-            <Text size="14" /> Lint Result
-          </TabsTrigger>
-        </TabsList>
-        <div className="h-full">
-          <TabsContent value="testcase" className="h-full bg-white">
-            <Card className="h-full">
-              <CardHeader>
-                <CardTitle>テストケースです</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                ここにテストケースが入ります。
-              </CardContent>
-            </Card>
-          </TabsContent>
-          <TabsContent value="testresult" className="h-full bg-white">
-            <Card className="h-full">
-              <CardHeader>
-                <CardTitle>テスト結果</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                ここにはテスト結果が並びます。
-              </CardContent>
-            </Card>
-          </TabsContent>
-          <TabsContent value="lintresult" className="h-full bg-white">
-            <Card className="h-full">
-              <CardHeader>
-                <CardTitle>Solutions</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                Linterの結果が出てきます。
-              </CardContent>
-              <CardFooter>Footer...</CardFooter>
-            </Card>
-          </TabsContent>
-        </div>
-      </Tabs>
-    </Card>
+    <Tabs defaultValue="testcase" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-31 で実装予定なので、今後不要 */>
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger value="testcase" className="w-full">
+          <SquareCheckBig size="14" />
+          Test Case
+        </TabsTrigger>
+        <TabsTrigger value="testresult" className="w-full">
+          <MonitorCheck size="14" />
+          Test Result
+        </TabsTrigger>
+        <TabsTrigger value="lintresult" className="w-full">
+          <Text size="14" /> Lint Result
+        </TabsTrigger>
+      </TabsList>
+        <TabsContent value="testcase" className="bg-white">
+          <Card className="h-full">
+            <CardHeader>
+              <CardTitle>テストケースです</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              ここにテストケースが入ります。
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="testresult" className="bg-white">
+          <Card className="h-full">
+            <CardHeader>
+              <CardTitle>テスト結果</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              ここにはテスト結果が並びます。
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="lintresult" className="bg-white">
+          <Card className="h-full">
+            <CardHeader>
+              <CardTitle>Solutions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              Linterの結果が出てきます。
+            </CardContent>
+            <CardFooter>Footer...</CardFooter>
+          </Card>
+        </TabsContent>
+    </Tabs>
   );
 };

--- a/app/components/test-tab.tsx
+++ b/app/components/test-tab.tsx
@@ -11,13 +11,7 @@ import { MonitorCheck, SquareCheckBig, Text } from 'lucide-react';
 
 export const TestTab = ({ className }: { className?: string }) => {
   return (
-    <Tabs
-      defaultValue="testcase"
-      className={cn(
-        'h-full',
-        className
-      )}
-    >
+    <Tabs defaultValue="testcase" className={cn('h-full', className)}>
       <TabsList>
         <TabsTrigger value="testcase">
           <SquareCheckBig size="14" />

--- a/app/components/test-tab.tsx
+++ b/app/components/test-tab.tsx
@@ -6,11 +6,18 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 import { MonitorCheck, SquareCheckBig, Text } from 'lucide-react';
 
-export const TestTab = () => {
+export const TestTab = ({ className }: { className?: string }) => {
   return (
-    <Tabs defaultValue="testcase" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */>
+    <Tabs
+      defaultValue="testcase"
+      className={cn(
+        'h-full flex flex-col [&:not(:first-child)]:*:flex-grow',
+        className
+      )} /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */
+    >
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="testcase" className="w-full">
           <SquareCheckBig size="14" />
@@ -24,37 +31,37 @@ export const TestTab = () => {
           <Text size="14" /> Lint Result
         </TabsTrigger>
       </TabsList>
-        <TabsContent value="testcase" className="bg-white">
-          <Card className="h-full">
-            <CardHeader>
-              <CardTitle>テストケースです</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              ここにテストケースが入ります。
-            </CardContent>
-          </Card>
-        </TabsContent>
-        <TabsContent value="testresult" className="bg-white">
-          <Card className="h-full">
-            <CardHeader>
-              <CardTitle>テスト結果</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              ここにはテスト結果が並びます。
-            </CardContent>
-          </Card>
-        </TabsContent>
-        <TabsContent value="lintresult" className="bg-white">
-          <Card className="h-full">
-            <CardHeader>
-              <CardTitle>Solutions</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              Linterの結果が出てきます。
-            </CardContent>
-            <CardFooter>Footer...</CardFooter>
-          </Card>
-        </TabsContent>
+      <TabsContent value="testcase" className="bg-white">
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle>テストケースです</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            ここにテストケースが入ります。
+          </CardContent>
+        </Card>
+      </TabsContent>
+      <TabsContent value="testresult" className="bg-white">
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle>テスト結果</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            ここにはテスト結果が並びます。
+          </CardContent>
+        </Card>
+      </TabsContent>
+      <TabsContent value="lintresult" className="bg-white">
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle>Solutions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            Linterの結果が出てきます。
+          </CardContent>
+          <CardFooter>Footer...</CardFooter>
+        </Card>
+      </TabsContent>
     </Tabs>
   );
 };

--- a/app/components/test-tab.tsx
+++ b/app/components/test-tab.tsx
@@ -10,7 +10,7 @@ import { MonitorCheck, SquareCheckBig, Text } from 'lucide-react';
 
 export const TestTab = () => {
   return (
-    <Tabs defaultValue="testcase" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-31 で実装予定なので、今後不要 */>
+    <Tabs defaultValue="testcase" className='h-full flex flex-col [&:not(:first-child)]:*:flex-grow' /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */>
       <TabsList className="grid w-full grid-cols-3">
         <TabsTrigger value="testcase" className="w-full">
           <SquareCheckBig size="14" />

--- a/app/components/test-tab.tsx
+++ b/app/components/test-tab.tsx
@@ -14,25 +14,25 @@ export const TestTab = ({ className }: { className?: string }) => {
     <Tabs
       defaultValue="testcase"
       className={cn(
-        'h-full flex flex-col [&:not(:first-child)]:*:flex-grow',
+        'h-full',
         className
-      )} /** flex 以降は DOJO-19 でデザインを修正予定なので、今後不要 */
+      )}
     >
-      <TabsList className="grid w-full grid-cols-3">
-        <TabsTrigger value="testcase" className="w-full">
+      <TabsList>
+        <TabsTrigger value="testcase">
           <SquareCheckBig size="14" />
           Test Case
         </TabsTrigger>
-        <TabsTrigger value="testresult" className="w-full">
+        <TabsTrigger value="testresult">
           <MonitorCheck size="14" />
           Test Result
         </TabsTrigger>
-        <TabsTrigger value="lintresult" className="w-full">
+        <TabsTrigger value="lintresult">
           <Text size="14" /> Lint Result
         </TabsTrigger>
       </TabsList>
-      <TabsContent value="testcase" className="bg-white">
-        <Card className="h-full">
+      <TabsContent value="testcase">
+        <Card className="border-0 shadow-none">
           <CardHeader>
             <CardTitle>テストケースです</CardTitle>
           </CardHeader>
@@ -41,8 +41,8 @@ export const TestTab = ({ className }: { className?: string }) => {
           </CardContent>
         </Card>
       </TabsContent>
-      <TabsContent value="testresult" className="bg-white">
-        <Card className="h-full">
+      <TabsContent value="testresult">
+        <Card className="border-0 shadow-none">
           <CardHeader>
             <CardTitle>テスト結果</CardTitle>
           </CardHeader>
@@ -51,8 +51,8 @@ export const TestTab = ({ className }: { className?: string }) => {
           </CardContent>
         </Card>
       </TabsContent>
-      <TabsContent value="lintresult" className="bg-white">
-        <Card className="h-full">
+      <TabsContent value="lintresult">
+        <Card className="border-0 shadow-none">
           <CardHeader>
             <CardTitle>Solutions</CardTitle>
           </CardHeader>

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,6 +50,7 @@ body {
     --difficulty-easy: 20 186 167;
     --difficulty-medium: 243 181 22;
     --difficulty-hard: 221 42 78;
+    --state-layers-primary: 101 85 143;
   }
   .dark {
     --background: 26 17 17;
@@ -88,6 +89,7 @@ body {
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --state-layers-primary: 208 188 255;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Header } from './layout/header';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -12,11 +13,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body>
-        <div className="w-screen h-screen">
-          <div className="w-full h-full">{children}</div>
-        </div>
+    <html lang="en" className="w-screen h-screen">
+      <body className="w-full h-full flex flex-col items-center sm:items-start">
+        <Header />
+        <main className="w-full h-full grow overflow-auto">{children}</main>
       </body>
     </html>
   );

--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -4,22 +4,22 @@ import { CircleUserRound, Play, Upload } from 'lucide-react';
 export const Header = () => {
   return (
     <div className="w-full px-6 py-2">
-        <div className="w-full flex justify-between items-center">
-          <div className="items-center">Alpha Dojo</div>
-          <div className="flex gap-2">
-            <Button variant="outline">
-              <Play />
-              Run
-            </Button>
-            <Button>
-              <Upload />
-              Submit
-            </Button>
-          </div>
-          <div className="items-center">
-            <CircleUserRound size="24" />
-          </div>
+      <div className="w-full flex justify-between items-center">
+        <div className="items-center">Alpha Dojo</div>
+        <div className="flex gap-2">
+          <Button variant="outline">
+            <Play />
+            Run
+          </Button>
+          <Button>
+            <Upload />
+            Submit
+          </Button>
         </div>
+        <div className="items-center">
+          <CircleUserRound size="24" />
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/layout/header.tsx
+++ b/app/layout/header.tsx
@@ -1,30 +1,25 @@
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { CircleUserRound, Play, Upload } from 'lucide-react';
 
 export const Header = () => {
   return (
-    <div className="w-screen h-9 mt-2">
-      <Card>
-        <CardContent>
-          <div className="w-full flex justify-between items-center">
-            <div className="items-center">Alpha Dojo</div>
-            <div className="flex gap-2">
-              <Button variant="outline">
-                <Play />
-                Run
-              </Button>
-              <Button>
-                <Upload />
-                Submit
-              </Button>
-            </div>
-            <div className="items-center">
-              <CircleUserRound size="24" />
-            </div>
+    <div className="w-full px-6 py-2">
+        <div className="w-full flex justify-between items-center">
+          <div className="items-center">Alpha Dojo</div>
+          <div className="flex gap-2">
+            <Button variant="outline">
+              <Play />
+              Run
+            </Button>
+            <Button>
+              <Upload />
+              Submit
+            </Button>
           </div>
-        </CardContent>
-      </Card>
+          <div className="items-center">
+            <CircleUserRound size="24" />
+          </div>
+        </div>
     </div>
   );
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,8 @@
 'use client';
-import { Header } from './layout/header';
 import { ProbremTab } from './components/problem-tab';
 import { TestTab } from './components/test-tab';
 import { CodeTab } from './components/code-tab';
-import Split from 'react-split'
+import Split from 'react-split';
 
 class Person {
   name: string = '';
@@ -25,19 +24,20 @@ samplePersons.push(new Person('dさん', 32, 'Osaka'));
 
 export default function Home() {
   return (
-    <main className="w-full h-full flex flex-col gap-2 items-center sm:items-start">
-      <Header />
+    <Split
+      direction="horizontal"
+      minSize={200}
+      className="flex w-full h-full px-2.5 pb-2.5 min-w-100 min-h-100"
+    >
+      <ProbremTab className="overflow-auto" />
       <Split
-        direction='horizontal'
-        className='flex w-full h-full px-2.5 pb-2.5'>
-        <ProbremTab />
-        <Split
-          direction='vertical'
-          className='flex w-full h-full flex-col'>
-          <CodeTab />
-          <TestTab />
-        </Split>
+        direction="vertical"
+        minSize={200}
+        className="flex w-full h-full flex-col"
+      >
+        <CodeTab className="overflow-auto" />
+        <TestTab className="overflow-auto" />
       </Split>
-    </main>
+    </Split>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { Header } from './layout/header';
 import { ProbremTab } from './components/problem-tab';
 import { TestTab } from './components/test-tab';
 import { CodeTab } from './components/code-tab';
+import Split from 'react-split'
 
 class Person {
   name: string = '';
@@ -26,11 +27,17 @@ export default function Home() {
   return (
     <main className="w-full h-full flex flex-col gap-2 items-center sm:items-start">
       <Header />
-      <div className="w-full h-full grid grid-cols-2 grid-rows-2 gap-2">
+      <Split
+        direction='horizontal'
+        className='flex w-full h-full px-2.5 pb-2.5'>
         <ProbremTab />
-        <CodeTab />
-        <TestTab />
-      </div>
+        <Split
+          direction='vertical'
+          className='flex w-full h-full flex-col'>
+          <CodeTab />
+          <TestTab />
+        </Split>
+      </Split>
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,35 +25,29 @@ samplePersons.push(new Person('cさん', 25, 'Nagoya'));
 samplePersons.push(new Person('dさん', 32, 'Osaka'));
 
 export default function Home() {
-  const splitVariants = cva(
-    'flex w-full h-full',
-    {
-      variants: {
-        direction: {
-          horizontal: 'flex-row',
-          vertical: 'flex-col',
-        },
+  const splitVariants = cva('flex w-full h-full', {
+    variants: {
+      direction: {
+        horizontal: 'flex-row',
+        vertical: 'flex-col',
       },
-      defaultVariants: {
-        direction: 'horizontal',
-      },
-    }
-  );
+    },
+    defaultVariants: {
+      direction: 'horizontal',
+    },
+  });
 
-  const gutterVariants = cva(
-    'flex items-center justify-center group',
-    {
-      variants: {
-        direction: {
-          horizontal: 'hover:cursor-col-resize',
-          vertical: 'hover:cursor-row-resize',
-        },
+  const gutterVariants = cva('flex items-center justify-center group', {
+    variants: {
+      direction: {
+        horizontal: 'hover:cursor-col-resize',
+        vertical: 'hover:cursor-row-resize',
       },
-      defaultVariants: {
-        direction: 'horizontal',
-      },
-    }
-  );
+    },
+    defaultVariants: {
+      direction: 'horizontal',
+    },
+  });
 
   const gutterChildVariants = cva(
     'bg-border-variant opacity-0 group-hover:opacity-100 transition-[opacity,width,height]',
@@ -61,7 +55,7 @@ export default function Home() {
       variants: {
         direction: {
           horizontal: 'w-1 h-full group-active:w-0.5',
-          vertical:   'h-1 w-full group-active:h-0.5',
+          vertical: 'h-1 w-full group-active:h-0.5',
         },
       },
       defaultVariants: {
@@ -81,11 +75,11 @@ export default function Home() {
       gutterSize: 10,
       gutter: () => {
         const gutterElement = document.createElement('div');
-        gutterElement.className = gutterVariants({direction});
+        gutterElement.className = gutterVariants({ direction });
 
         // 子要素 (区切り線の可視化・アニメーション)
         const gutterChild = document.createElement('div');
-        gutterChild.className = gutterChildVariants({direction});
+        gutterChild.className = gutterChildVariants({ direction });
         gutterElement.appendChild(gutterChild);
 
         return gutterElement;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,9 @@
 import { ProbremTab } from './components/problem-tab';
 import { TestTab } from './components/test-tab';
 import { CodeTab } from './components/code-tab';
-import Split from 'react-split';
+import Split, { SplitProps } from 'react-split';
+import { cn } from '@/lib/utils';
+import { cva } from 'class-variance-authority';
 
 class Person {
   name: string = '';
@@ -23,18 +25,78 @@ samplePersons.push(new Person('cさん', 25, 'Nagoya'));
 samplePersons.push(new Person('dさん', 32, 'Osaka'));
 
 export default function Home() {
+  const splitVariants = cva(
+    'flex w-full h-full',
+    {
+      variants: {
+        direction: {
+          horizontal: 'flex-row',
+          vertical: 'flex-col',
+        },
+      },
+      defaultVariants: {
+        direction: 'horizontal',
+      },
+    }
+  );
+
+  const gutterVariants = cva(
+    'flex items-center justify-center group',
+    {
+      variants: {
+        direction: {
+          horizontal: 'hover:cursor-col-resize',
+          vertical: 'hover:cursor-row-resize',
+        },
+      },
+      defaultVariants: {
+        direction: 'horizontal',
+      },
+    }
+  );
+
+  const gutterChildVariants = cva(
+    'bg-border-variant opacity-0 group-hover:opacity-100 transition-[opacity,width,height]',
+    {
+      variants: {
+        direction: {
+          horizontal: 'w-1 h-full group-active:w-0.5',
+          vertical:   'h-1 w-full group-active:h-0.5',
+        },
+      },
+      defaultVariants: {
+        direction: 'horizontal',
+      },
+    }
+  );
+
+  const splitProps = (
+    direction: 'horizontal' | 'vertical' | undefined,
+    className?: string
+  ): SplitProps => {
+    return {
+      direction,
+      minSize: 200,
+      className: cn(splitVariants({ direction, className })),
+      gutterSize: 10,
+      gutter: () => {
+        const gutterElement = document.createElement('div');
+        gutterElement.className = gutterVariants({direction});
+
+        // 子要素 (区切り線の可視化・アニメーション)
+        const gutterChild = document.createElement('div');
+        gutterChild.className = gutterChildVariants({direction});
+        gutterElement.appendChild(gutterChild);
+
+        return gutterElement;
+      },
+    };
+  };
+
   return (
-    <Split
-      direction="horizontal"
-      minSize={200}
-      className="flex w-full h-full px-2.5 pb-2.5 min-w-100 min-h-100"
-    >
+    <Split {...splitProps('horizontal', 'px-2.5 pb-2.5 min-w-100 min-h-100')}>
       <ProbremTab className="overflow-auto" />
-      <Split
-        direction="vertical"
-        minSize={200}
-        className="flex w-full h-full flex-col"
-      >
+      <Split {...splitProps('vertical')}>
         <CodeTab className="overflow-auto" />
         <TestTab className="overflow-auto" />
       </Split>

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -30,7 +30,7 @@ const TabsList = React.forwardRef<
       // shadcn original:
       // "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
       "inline-flex h-10 items-center justify-center bg-neutral-200 p-1 text-muted-foreground",
-      "gap-1 flex justify-start",
+      "gap-1 flex justify-start text-primary",
       className
     )}
     {...props}
@@ -48,8 +48,8 @@ const TabsTrigger = React.forwardRef<
       className={cn(
         // shadcn original:
         // "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-        "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-4 py-1.5 text-label-medium-prominent font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
-        "gap-2 !w-auto",
+        "inline-flex items-center justify-center whitespace-nowrap rounded-lg px-4 py-1.5 text-label-medium-prominent ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-state-layers-primary/12 data-[state=active]:shadow-sm",
+        "gap-2 !w-auto hover:bg-state-layers-primary/8",
         // 子要素の Material Symbols のフォントサイズは 18px が既定
         '[&_[class^="material-symbols-"]]:[&>_]:text-[18px]',
         className

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
+    "@types/react-grid-layout": "^1.3.5",
     "@typescript-eslint/parser": "^8.15.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -24,6 +25,7 @@
     "next": "15.0.2",
     "react": "19.0.0-rc-02c0e824-20241028",
     "react-dom": "19.0.0-rc-02c0e824-20241028",
+    "react-grid-layout": "^1.5.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
-    "@types/react-grid-layout": "^1.3.5",
     "@typescript-eslint/parser": "^8.15.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -25,7 +24,6 @@
     "next": "15.0.2",
     "react": "19.0.0-rc-02c0e824-20241028",
     "react-dom": "19.0.0-rc-02c0e824-20241028",
-    "react-grid-layout": "^1.5.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "15.0.2",
     "react": "19.0.0-rc-02c0e824-20241028",
     "react-dom": "19.0.0-rc-02c0e824-20241028",
+    "react-split": "^2.0.14",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.3
         version: 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
-      '@types/react-grid-layout':
-        specifier: ^1.3.5
-        version: 1.3.5
       '@typescript-eslint/parser':
         specifier: ^8.15.0
         version: 8.15.0(eslint@8.57.1)(typescript@5.6.3)
@@ -53,9 +50,6 @@ importers:
       react-dom:
         specifier: 19.0.0-rc-02c0e824-20241028
         version: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
-      react-grid-layout:
-        specifier: ^1.5.0
-        version: 1.5.0(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -839,9 +833,6 @@ packages:
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
-  '@types/react-grid-layout@1.3.5':
-    resolution: {integrity: sha512-WH/po1gcEcoR6y857yAnPGug+ZhkF4PaTUxgAbwfeSH/QOgVSakKHBXoPGad/sEznmkiaK3pqHk+etdWisoeBQ==}
-
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
@@ -1094,10 +1085,6 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-
-  clsx@1.2.1:
-    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
-    engines: {node: '>=6'}
 
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
@@ -1415,9 +1402,6 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-equals@4.0.3:
-    resolution: {integrity: sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2162,18 +2146,6 @@ packages:
     peerDependencies:
       react: 19.0.0-rc-02c0e824-20241028
 
-  react-draggable@4.4.6:
-    resolution: {integrity: sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==}
-    peerDependencies:
-      react: '>= 16.3.0'
-      react-dom: '>= 16.3.0'
-
-  react-grid-layout@1.5.0:
-    resolution: {integrity: sha512-WBKX7w/LsTfI99WskSu6nX2nbJAUD7GD6nIXcwYLyPpnslojtmql2oD3I2g5C3AK8hrxIarYT8awhuDIp7iQ5w==}
-    peerDependencies:
-      react: '>= 16.3.0'
-      react-dom: '>= 16.3.0'
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2196,11 +2168,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-resizable@3.0.5:
-    resolution: {integrity: sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==}
-    peerDependencies:
-      react: '>= 16.3'
 
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
@@ -2238,9 +2205,6 @@ packages:
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
-
-  resize-observer-polyfill@1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3332,10 +3296,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.12
 
-  '@types/react-grid-layout@1.3.5':
-    dependencies:
-      '@types/react': 18.3.12
-
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.13
@@ -3637,8 +3597,6 @@ snapshots:
   client-only@0.0.1: {}
 
   clone@1.0.4: {}
-
-  clsx@1.2.1: {}
 
   clsx@2.0.0: {}
 
@@ -4089,8 +4047,6 @@ snapshots:
       strip-final-newline: 3.0.0
 
   fast-deep-equal@3.1.3: {}
-
-  fast-equals@4.0.3: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -4806,24 +4762,6 @@ snapshots:
       react: 19.0.0-rc-02c0e824-20241028
       scheduler: 0.25.0-rc-02c0e824-20241028
 
-  react-draggable@4.4.6(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
-    dependencies:
-      clsx: 1.2.1
-      prop-types: 15.8.1
-      react: 19.0.0-rc-02c0e824-20241028
-      react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
-
-  react-grid-layout@1.5.0(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
-    dependencies:
-      clsx: 2.1.1
-      fast-equals: 4.0.3
-      prop-types: 15.8.1
-      react: 19.0.0-rc-02c0e824-20241028
-      react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
-      react-draggable: 4.4.6(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
-      react-resizable: 3.0.5(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
-      resize-observer-polyfill: 1.5.1
-
   react-is@16.13.1: {}
 
   react-remove-scroll-bar@2.3.6(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028):
@@ -4844,14 +4782,6 @@ snapshots:
       use-sidecar: 1.1.2(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028)
     optionalDependencies:
       '@types/react': 18.3.12
-
-  react-resizable@3.0.5(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.0.0-rc-02c0e824-20241028
-      react-draggable: 4.4.6(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
-    transitivePeerDependencies:
-      - react-dom
 
   react-style-singleton@2.2.1(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028):
     dependencies:
@@ -4902,8 +4832,6 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
-
-  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.3
         version: 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
+      '@types/react-grid-layout':
+        specifier: ^1.3.5
+        version: 1.3.5
       '@typescript-eslint/parser':
         specifier: ^8.15.0
         version: 8.15.0(eslint@8.57.1)(typescript@5.6.3)
@@ -50,6 +53,9 @@ importers:
       react-dom:
         specifier: 19.0.0-rc-02c0e824-20241028
         version: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
+      react-grid-layout:
+        specifier: ^1.5.0
+        version: 1.5.0(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -833,6 +839,9 @@ packages:
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
+  '@types/react-grid-layout@1.3.5':
+    resolution: {integrity: sha512-WH/po1gcEcoR6y857yAnPGug+ZhkF4PaTUxgAbwfeSH/QOgVSakKHBXoPGad/sEznmkiaK3pqHk+etdWisoeBQ==}
+
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
@@ -1085,6 +1094,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
 
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
@@ -1402,6 +1415,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@4.0.3:
+    resolution: {integrity: sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2146,6 +2162,18 @@ packages:
     peerDependencies:
       react: 19.0.0-rc-02c0e824-20241028
 
+  react-draggable@4.4.6:
+    resolution: {integrity: sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==}
+    peerDependencies:
+      react: '>= 16.3.0'
+      react-dom: '>= 16.3.0'
+
+  react-grid-layout@1.5.0:
+    resolution: {integrity: sha512-WBKX7w/LsTfI99WskSu6nX2nbJAUD7GD6nIXcwYLyPpnslojtmql2oD3I2g5C3AK8hrxIarYT8awhuDIp7iQ5w==}
+    peerDependencies:
+      react: '>= 16.3.0'
+      react-dom: '>= 16.3.0'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -2168,6 +2196,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-resizable@3.0.5:
+    resolution: {integrity: sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==}
+    peerDependencies:
+      react: '>= 16.3'
 
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
@@ -2205,6 +2238,9 @@ packages:
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
+
+  resize-observer-polyfill@1.5.1:
+    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3296,6 +3332,10 @@ snapshots:
     dependencies:
       '@types/react': 18.3.12
 
+  '@types/react-grid-layout@1.3.5':
+    dependencies:
+      '@types/react': 18.3.12
+
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.13
@@ -3597,6 +3637,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clone@1.0.4: {}
+
+  clsx@1.2.1: {}
 
   clsx@2.0.0: {}
 
@@ -4047,6 +4089,8 @@ snapshots:
       strip-final-newline: 3.0.0
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@4.0.3: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -4762,6 +4806,24 @@ snapshots:
       react: 19.0.0-rc-02c0e824-20241028
       scheduler: 0.25.0-rc-02c0e824-20241028
 
+  react-draggable@4.4.6(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
+    dependencies:
+      clsx: 1.2.1
+      prop-types: 15.8.1
+      react: 19.0.0-rc-02c0e824-20241028
+      react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
+
+  react-grid-layout@1.5.0(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
+    dependencies:
+      clsx: 2.1.1
+      fast-equals: 4.0.3
+      prop-types: 15.8.1
+      react: 19.0.0-rc-02c0e824-20241028
+      react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
+      react-draggable: 4.4.6(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
+      react-resizable: 3.0.5(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
+      resize-observer-polyfill: 1.5.1
+
   react-is@16.13.1: {}
 
   react-remove-scroll-bar@2.3.6(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028):
@@ -4782,6 +4844,14 @@ snapshots:
       use-sidecar: 1.1.2(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028)
     optionalDependencies:
       '@types/react': 18.3.12
+
+  react-resizable@3.0.5(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.0.0-rc-02c0e824-20241028
+      react-draggable: 4.4.6(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
+    transitivePeerDependencies:
+      - react-dom
 
   react-style-singleton@2.2.1(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028):
     dependencies:
@@ -4832,6 +4902,8 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
+
+  resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-dom:
         specifier: 19.0.0-rc-02c0e824-20241028
         version: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
+      react-split:
+        specifier: ^2.0.14
+        version: 2.0.14(react@19.0.0-rc-02c0e824-20241028)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -2169,6 +2172,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-split@2.0.14:
+    resolution: {integrity: sha512-bKWydgMgaKTg/2JGQnaJPg51T6dmumTWZppFgEbbY0Fbme0F5TuatAScCLaqommbGQQf/ZT1zaejuPDriscISA==}
+    peerDependencies:
+      react: '*'
+
   react-style-singleton@2.2.1:
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
@@ -2308,6 +2316,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  split.js@1.6.5:
+    resolution: {integrity: sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==}
 
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
@@ -4783,6 +4794,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  react-split@2.0.14(react@19.0.0-rc-02c0e824-20241028):
+    dependencies:
+      prop-types: 15.8.1
+      react: 19.0.0-rc-02c0e824-20241028
+      split.js: 1.6.5
+
   react-style-singleton@2.2.1(@types/react@18.3.12)(react@19.0.0-rc-02c0e824-20241028):
     dependencies:
       get-nonce: 1.0.1
@@ -4981,6 +4998,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  split.js@1.6.5: {}
 
   stdin-discarder@0.1.0:
     dependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -81,6 +81,9 @@ const config: Config = {
 				easy: 'rgb(var(--difficulty-easy))',
 				medium: 'rgb(var(--difficulty-medium))',
 				hard: 'rgb(var(--difficulty-hard))'
+			},
+			'state-layers': {
+				primary: 'rgb(var(--state-layers-primary))'
 			}
   		},
   		borderRadius: {
@@ -89,10 +92,15 @@ const config: Config = {
   			sm: 'calc(var(--radius) - 4px)'
   		},
 		fontSize: {
+			"body-small":             ['12px', {fontWeight: '400', letterSpacing: '0.4px', lineHeight: '16px'}],
 			"label-medium-prominent": ['12px', {fontWeight: '600', letterSpacing: '0.5px', lineHeight: '16px'}]
 		},
 		spacing: {
 			'100': '25rem'
+		},
+		opacity: {
+			'8': '.08',
+			'12': '.12',
 		}
   	}
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -85,6 +85,9 @@ const config: Config = {
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
   		},
+		spacing: {
+			'100': '25rem'
+		}
   	}
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
# Jira
https://alpha-dojo.atlassian.net/browse/DOJO-31?atlOrigin=eyJpIjoiMjRkOTFkNGVhOGViNGZiNDgwZWM0MTNlMTcwOTVkMTUiLCJwIjoiaiJ9

# 内容
* `submissions/:id/edit` ページに Splitter を導入しました
* `problem-tab`, `code-tab`, `test-tab` の各タブのデザインを修正しました
* `header`, `main` 要素の挿入位置を変更しました
    * conflict が発生するかも

# 検討したこと
* 不採用: [`React-Grid-Layout`](https://github.com/react-grid-layout/react-grid-layout)
    * コンポーネントの移動はやりやすい
    * Splitter 向けのライブラリではないため、今回は不採用
* 不採用: [`react-split-pane`](https://github.com/tomkp/react-split-pane)
    * React 18 に対応するための 2022 年の Issue が未だ解決されておらず、開発がほぼ停止？
    * 将来性を考えて不採用
* **採用 [`react-split`](https://github.com/nathancahill/split)**
    * 仕様が簡単でわかりやすい
    * [デモサイト](https://split.js.org/) のデザインが気に入った

# 今後やりたいこと
* タブの移動機能 (優先度 低)
    * [`React DnD`](https://github.com/react-dnd/react-dnd/) を併用すればできるかも？？

# スクリーンショット
https://github.com/user-attachments/assets/35a5857e-9eb4-4478-af9e-3eb309e0f37f