### PR TITLE
[DOJO-60] Strapi の Admin panel の日本語化

### DIFF
--- a/strapi/src/admin/app.tsx
+++ b/strapi/src/admin/app.tsx
@@ -12,7 +12,7 @@ export default {
       // 'he',
       // 'id',
       // 'it',
-      // 'ja',
+      'ja',
       // 'ko',
       // 'ms',
       // 'nl',


### PR DESCRIPTION
# やったこと
* Strapi の Admin panel の日本語化
    * 画面の全部は翻訳されていません

# スクリーンショット
![image](https://github.com/user-attachments/assets/b4466687-429f-4b42-8bb9-cffd663bdd0f)
