### PR TITLE
[DOJO-61] Strapi の submission モデルの作成

### DIFF
--- a/strapi/src/api/initial-code/content-types/initial-code/schema.json
+++ b/strapi/src/api/initial-code/content-types/initial-code/schema.json
@@ -19,9 +19,8 @@
     },
     "language": {
       "type": "relation",
-      "relation": "manyToOne",
-      "target": "api::language.language",
-      "inversedBy": "initial_codes"
+      "relation": "oneToOne",
+      "target": "api::language.language"
     },
     "code": {
       "type": "customField",

--- a/strapi/src/api/initial-code/content-types/initial-code/schema.json
+++ b/strapi/src/api/initial-code/content-types/initial-code/schema.json
@@ -11,13 +11,13 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "problem_id": {
+    "problem": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::problem.problem",
       "inversedBy": "initial_codes"
     },
-    "language_id": {
+    "language": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::language.language",

--- a/strapi/src/api/language/content-types/language/schema.json
+++ b/strapi/src/api/language/content-types/language/schema.json
@@ -12,18 +12,6 @@
   "attributes": {
     "name": {
       "type": "string"
-    },
-    "initial_codes": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::initial-code.initial-code",
-      "mappedBy": "language"
-    },
-    "validators": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::validator.validator",
-      "mappedBy": "language"
     }
   }
 }

--- a/strapi/src/api/language/content-types/language/schema.json
+++ b/strapi/src/api/language/content-types/language/schema.json
@@ -13,17 +13,17 @@
     "name": {
       "type": "string"
     },
-    "validators": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::validator.validator",
-      "mappedBy": "language_id"
-    },
     "initial_codes": {
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::initial-code.initial-code",
-      "mappedBy": "language_id"
+      "mappedBy": "language"
+    },
+    "validators": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::validator.validator",
+      "mappedBy": "language"
     }
   }
 }

--- a/strapi/src/api/problem/content-types/problem/schema.json
+++ b/strapi/src/api/problem/content-types/problem/schema.json
@@ -29,12 +29,6 @@
     "constraints": {
       "type": "richtext"
     },
-    "validators": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::validator.validator",
-      "mappedBy": "problem_id"
-    },
     "hints": {
       "type": "relation",
       "relation": "oneToMany",
@@ -45,13 +39,19 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::initial-code.initial-code",
-      "mappedBy": "problem_id"
+      "mappedBy": "problem"
     },
     "test_cases": {
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::test-case.test-case",
-      "mappedBy": "problem_id"
+      "mappedBy": "problem"
+    },
+    "validators": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::validator.validator",
+      "mappedBy": "problem"
     }
   }
 }

--- a/strapi/src/api/problem/content-types/problem/schema.json
+++ b/strapi/src/api/problem/content-types/problem/schema.json
@@ -52,6 +52,12 @@
       "relation": "oneToMany",
       "target": "api::validator.validator",
       "mappedBy": "problem"
+    },
+    "submissions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::submission.submission",
+      "mappedBy": "problem"
     }
   }
 }

--- a/strapi/src/api/submission/content-types/submission/schema.json
+++ b/strapi/src/api/submission/content-types/submission/schema.json
@@ -29,9 +29,6 @@
     },
     "code": {
       "type": "customField",
-      "options": {
-        "language": "typescript"
-      },
       "customField": "plugin::strapi-code-editor-custom-field.code-editor-text"
     },
     "test_result_id": {

--- a/strapi/src/api/submission/content-types/submission/schema.json
+++ b/strapi/src/api/submission/content-types/submission/schema.json
@@ -1,0 +1,41 @@
+{
+  "kind": "collectionType",
+  "collectionName": "submissions",
+  "info": {
+    "singularName": "submission",
+    "pluralName": "submissions",
+    "displayName": "Submission"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "author": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.user",
+      "inversedBy": "submissions"
+    },
+    "problem": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::problem.problem",
+      "inversedBy": "submissions"
+    },
+    "language": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::language.language"
+    },
+    "code": {
+      "type": "customField",
+      "options": {
+        "language": "typescript"
+      },
+      "customField": "plugin::strapi-code-editor-custom-field.code-editor-text"
+    },
+    "test_result_id": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/src/api/submission/controllers/submission.ts
+++ b/strapi/src/api/submission/controllers/submission.ts
@@ -1,0 +1,7 @@
+/**
+ * submission controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::submission.submission');

--- a/strapi/src/api/submission/routes/submission.ts
+++ b/strapi/src/api/submission/routes/submission.ts
@@ -1,0 +1,7 @@
+/**
+ * submission router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::submission.submission');

--- a/strapi/src/api/submission/services/submission.ts
+++ b/strapi/src/api/submission/services/submission.ts
@@ -1,0 +1,7 @@
+/**
+ * submission service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::submission.submission');

--- a/strapi/src/api/test-case/content-types/test-case/schema.json
+++ b/strapi/src/api/test-case/content-types/test-case/schema.json
@@ -11,7 +11,7 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "problem_id": {
+    "problem": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::problem.problem",

--- a/strapi/src/api/validator/content-types/validator/schema.json
+++ b/strapi/src/api/validator/content-types/validator/schema.json
@@ -11,13 +11,13 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "problem_id": {
+    "problem": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::problem.problem",
       "inversedBy": "validators"
     },
-    "language_id": {
+    "language": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::language.language",

--- a/strapi/src/api/validator/content-types/validator/schema.json
+++ b/strapi/src/api/validator/content-types/validator/schema.json
@@ -19,9 +19,8 @@
     },
     "language": {
       "type": "relation",
-      "relation": "manyToOne",
-      "target": "api::language.language",
-      "inversedBy": "validators"
+      "relation": "oneToOne",
+      "target": "api::language.language"
     },
     "code": {
       "type": "customField",

--- a/strapi/src/extensions/users-permissions/content-types/user/schema.json
+++ b/strapi/src/extensions/users-permissions/content-types/user/schema.json
@@ -1,0 +1,76 @@
+{
+  "kind": "collectionType",
+  "collectionName": "up_users",
+  "info": {
+    "name": "user",
+    "description": "",
+    "singularName": "user",
+    "pluralName": "users",
+    "displayName": "User"
+  },
+  "options": {
+    "draftAndPublish": false,
+    "timestamps": true
+  },
+  "attributes": {
+    "username": {
+      "type": "string",
+      "minLength": 3,
+      "unique": true,
+      "configurable": false,
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "minLength": 6,
+      "configurable": false,
+      "required": true
+    },
+    "provider": {
+      "type": "string",
+      "configurable": false
+    },
+    "password": {
+      "type": "password",
+      "minLength": 6,
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "resetPasswordToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "confirmationToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "confirmed": {
+      "type": "boolean",
+      "default": false,
+      "configurable": false
+    },
+    "blocked": {
+      "type": "boolean",
+      "default": false,
+      "configurable": false
+    },
+    "role": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.role",
+      "inversedBy": "users",
+      "configurable": false
+    },
+    "submissions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::submission.submission",
+      "mappedBy": "author"
+    }
+  }
+}


### PR DESCRIPTION
## Jira
[DOJO-61](https://alpha-dojo.atlassian.net/browse/DOJO-61?atlOrigin=eyJpIjoiNWM5NTI3NjIzYjFiNDhjN2E1N2M0OGI5OTM3MWU2NWMiLCJwIjoiaiJ9)

## やったこと
* Strapi で Submission を定義
* Strapi の attributes から `_id` を削除
    * Strapi の Relations では ID が保存されているのではなく、コンテンツの実体が入っているようだ
* Language への Relation を `manyToOne` -> `oneToOne` に変更
    * Language から Initial Code や Validator をリストする必要は無いので、1 方向の参照で十分